### PR TITLE
Baseline correction only for DRIFTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,30 @@ Import two data sets of the same size which contain spectra of your choice and c
 ###### Input needed:
 RawData.txt, ReferenceData.txt of the same size
 ###### Output:
-FilenameOfYourRawData_TRS_Spektrum.txt
+FilenameOfYourRawData_TRS_Spectrum.txt
   
-#### peak picking:
+#### point picking:
 Imports a spectrum of your choice in which you can click on points of your choice in the spectrum to save all chosen
 energy/frequency/wavenumber/wavelength into a.txt file. After clicking for the first time and thus creating your file,
 every other click overwrites the existing file with the data points which were clicked on in the current window.
 ###### Input needed:
 RawData.txt or ProcessedData.txt (any kind of spectrum suffices)
 ###### Output:
-FilenameOfYourRawData_Banden.txt
+FilenameOfYourRawData_Peaks.txt
+
+#### baseline:
+Generates a baseline for each spectrum by connecting picked points to straights.
+###### Input needed:
+RawData.txt, ReferenceData.txt of the same size (only if you want to process modulated difference spectra, otherwise press Esc),
+FilenameOfYourRawData_Peaks.txt
+###### Output:
+FilenameOfYourRawData_Baseline.txt
   
 #### show peaks:
-Import a data set with energy/frequency/wavenumber/wavelength values (which you may create e. g. via the button 'peak
+Import a data set with energy/frequency/wavenumber/wavelength values (which you may create e. g. via the button 'point
 picking') and highlight these positions in your latest matplotlib window as red vertical lines.
 ###### Input needed:
-AnyData.txt, AnyData_Banden.txt
+AnyData.txt, AnyData_Peaks.txt
 ###### Output:
 None
   
@@ -57,9 +65,9 @@ Import a data set of PSD spectra, peak positions of your choice and the temporal
 spectra to determine for every band at which phase angle it has its maximum value. Temporal data and a correct input in the
 first textbox (number of spectra per period) is needed to calculate time values out of the maximum phase angles.
 ###### Input needed:
-PSDData.txt, AnyData_Banden.txt, RawData_t.txt, correct 'number of spectra per period' in first textbox
+PSDData.txt, AnyData_Peaks.txt, RawData_t.txt, correct 'number of spectra per period' in first textbox
 ###### Output:
-PSDData_Banden_iPW.txt
+PSDData_Peaks_iPW.txt
   
 #### show graph:
 Plots a data set of your choice.
@@ -83,6 +91,6 @@ Plots the temporal course of bands of your choice from your time resolved data i
 ###### Input needed:
 RawData.txt, ReferenceData.txt of the same size (only if you want to process modulated difference spectra, otherwise hit Esc)
 time values as a file with the same name as the raw data with the addition of _t ('FilenameOfYourRawData_t.txt') which contains
-temporal data as acolumn vector and AnyData_Banden.txt, 
+temporal data as acolumn vector and AnyData_Peaks.txt, 
 ###### Output:
 None

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -28,8 +28,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 # The following two lines import stylesheets to format graphs. If you don't have any, comment them out
-if os.environ['LOGNAME'] == 'jakub' :
-    plt.style.use('/home/jakub/HESSENBOX-DA/Diverses/TU_Design.mplstyle')
+#if os.environ['LOGNAME'] == 'jakub' :
+#    plt.style.use('/home/jakub/HESSENBOX-DA/Diverses/TU_Design.mplstyle')
 
 '''
 _______________________________________________________________________________
@@ -494,6 +494,15 @@ Entry_dphi = StringVar()
 
 PSD_GUI.title('Have fun with PSD!')
 
+Label_DD_instrument = Label(PSD_GUI, text = 'Choose your instrument/software!').pack()
+
+instrument_list = {'Bruker/OPUS (DRIFTS)', 'Horiba/LabSpec (Raman)'}
+instrument = StringVar(PSD_GUI)
+instrument.set('Bruker/OPUS (DRIFTS)')
+DD_instrument = OptionMenu(PSD_GUI, instrument, *instrument_list)
+DD_instrument.config(width=25)
+DD_instrument.pack()
+
 Label_n_sp = Label(PSD_GUI, text = 'Type in the number of spectra per period!').pack()
 
 Entry_n_sp = Entry(PSD_GUI, textvariable = Entry_n_sp)
@@ -521,7 +530,7 @@ DD_yUnit = OptionMenu(PSD_GUI, yUnit, *yUnit_list)
 DD_yUnit.config(width=14)
 DD_yUnit.pack()
 
-Label_DD_yUnit = Label(PSD_GUI, text = 'Choose your x label!').pack()
+Label_DD_xUnit = Label(PSD_GUI, text = 'Choose your x label!').pack()
 
 xUnit_list = {'Wavenumber in 1/cm': r'$\tilde{\nu}$ / cm$^{-1}$', 'Energy in eV': r'$E$ / eV', 'Wavelength in nm': r'$\lambda$ / nm', 'Raman Shift in 1/cm': r'$\Delta\tilde{\nu}$ / cm$^{-1}$'}
 xUnit = StringVar(PSD_GUI)

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -344,16 +344,28 @@ def in_phase_angle():
     for val in peak_pos:
         peak_pos[i] = min(psd_spectra.Wavenumber, key=lambda x:abs(x-val))
         i = i+1
-        
-    # read time values to convert the maximum phase angle into a time value
     
-    text = 'Path of your time values'
-    name_t = FileOpen(text)
-    t_inp = np.genfromtxt(r''+name_t, delimiter="\t")
+    # Reading time values of different instruments/software having different formats
+    if instrument.get() == "Bruker/OPUS (DRIFTS)":
+        text = 'Path of your time values'
+        name_t = FileOpen(text)
+        t_inp = np.genfromtxt(r''+name_t, delimiter="\t")
+            
+    elif instrument.get() == "Horiba/LabSpec (Raman)":
+        text = 'Path of your catalyst spectra because of needed time values'
+        name_dataCat = FileOpen(text)
+        dataCat = pd.read_csv(r''+name_dataCat, sep="\t", header = None)
+        dataCat = dataCat.values     
+        
+        # Calculating t_inp into seconds
+        t_inp = dataCat[1:,0]
+        t_inp = np.reshape(t_inp,(t_inp.size,1))
+        t_inp = (t_inp - t_inp[0]) * 24 * 3600
+        t_inp = t_inp + t_inp[1]
     
     # If t_inp is 1D array convert to 2D array for proper indexing
-    if t_inp.ndim == 1:
-        t_inp = np.reshape(t_inp,(t_inp.size,1))
+    #if t_inp.ndim == 1:
+    #    t_inp = np.reshape(t_inp,(t_inp.size,1))
         
     n_sp = int(Entry_n_sp.get())
     tges = t_inp[n_sp-1,0]

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -166,6 +166,7 @@ def PSD_calc(): # Calculates PSD spectra
         i = i+1
         
     # Definition of values for the fourier transformation
+    
     t_per = t_inp[n_sp-1,0]
     omega = 2*np.pi/t_per # omega in s^-1
     phi = np.arange(0,361,dphi) # phi is the phase shift which occurs as answer of the system to the external stimulation in the experiment
@@ -505,13 +506,17 @@ def in_phase_angle():
     # Needs to round because pandas uses more decimals than numpy
     psd_spectra.Wavenumber = pd.Series([round(val, 5) for val in psd_spectra.Wavenumber], index = psd_spectra.index)
     
+    
+    if psd_spectra['Wavenumber'].iloc[0] > psd_spectra['Wavenumber'].iloc[-1]: # Bring psd_spectra in an ascending order if they are not already
+        psd_spectra = psd_spectra.iloc[::-1]
+    
     text = 'Path of your peaks'
     name_peaks = FileOpen(text)
     peak_pos = np.genfromtxt(r''+name_peaks, delimiter="\n")
-    # peak_pos = peak_pos[::-1] #Needs to be inverted otherwise it is the wrong way around!
     
-    '''Compares every value in peak_pos with the wavenumbers from psd_spectra
-    and the closest value is taken'''
+    peak_pos = np.sort(peak_pos) # sort peaks in ascending order
+    
+    # Compares every value in peak_pos with the wavenumbers from psd_spectra and the closest value is taken'''
     i = 0
     for val in peak_pos:
         peak_pos[i] = min(psd_spectra.Wavenumber, key=lambda x:abs(x-val))
@@ -779,7 +784,7 @@ def course():
     
     # Save data frame to a file?
     
-    text = 'Shall the difference spectra be saved as .txt?'
+    text = 'Shall the course be saved as .txt?'
     name = name_dataCat.split('.') #Will be used as filename
     name = name[0] + '_course.txt'
     yesno(name, output, text)

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -284,10 +284,11 @@ def PointPicking():
     fig = plt.figure()
     text = 'Path of your spectra'
     name_dataSpectra = FileOpen(text)
-    dataSpectra = pd.read_csv(r''+name_dataSpectra, sep="\t")
-    dataSpectra = dataSpectra.values
 
     if 'PSD' in name_dataSpectra:
+        # Data of PSD spectra
+        dataSpectra = pd.read_csv(r''+name_dataSpectra, sep="\t")
+        dataSpectra = dataSpectra.values
         # Plot all spectra at once
         plt.clf()
         plt.xlabel(xUnit_list[xUnit.get()]) # Gets x axis label
@@ -319,11 +320,31 @@ def PointPicking():
         n_sp = int(Entry_n_sp.get()) # Number of spectra per period
         cutoff_per = int(Entry_cutoff_per.get()) #Number of periods to cut off
         cutoff_sp = n_sp*cutoff_per # Calculated number of spectra to cut off
-        name_t = name_dataSpectra.split('.')
-        name_t = name_t[0] + '_t.' + name_t[1]
         
-        t_inp = np.genfromtxt(r''+name_t, delimiter="\t")
-        
+        # Reading data of different instruments/software having different formats
+        if instrument.get() == "Bruker/OPUS (DRIFTS)":
+            # Data of catalyst spectra
+            dataSpectra = pd.read_csv(r''+name_dataSpectra, sep="\t")
+            dataSpectra = dataSpectra.values
+            
+            name_t = name_dataSpectra.split('.')
+            name_t = name_t[0] + '_t.' + name_t[1]        
+            t_inp = np.genfromtxt(r''+name_t, delimiter="\t")
+                
+        elif instrument.get() == "Horiba/LabSpec (Raman)":
+            # Data of catalyst spectra
+            dataSpectra = pd.read_csv(r''+name_dataSpectra, sep="\t", header = None)
+            dataSpectra = dataSpectra.values
+            
+            # Calculating t_inp into seconds
+            t_inp = dataSpectra[1:,0]
+            t_inp = np.reshape(t_inp,(t_inp.size,1))
+            t_inp = (t_inp - t_inp[0]) * 24 * 3600
+            t_inp = t_inp + t_inp[1]
+            
+            dataSpectra = np.delete(dataSpectra, 0, axis=1)
+            dataSpectra = dataSpectra.T
+       
         if cutoff_sp != 0:
             # Cut off spectra from the beginning
             dataSpectra = np.delete(dataSpectra, np.s_[1:cutoff_sp+1], axis = 1)

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -221,6 +221,27 @@ def Spectra_diff():
     text = 'Path of your reference spectra'
     name_dataRef = FileOpen(text)
     
+    # Reading data of different instruments/software having different formats
+    if instrument.get() == "Bruker/OPUS (DRIFTS)":
+        # Data of catalyst spectra and reference spectra
+        dataCat = pd.read_csv(r''+name_dataCat, sep="\t", header = None)
+        dataCat = dataCat.values
+        
+        dataRef = pd.read_csv(r''+name_dataRef, sep="\t", header = None)
+        dataRef = dataRef.values
+            
+    elif instrument.get() == "Horiba/LabSpec (Raman)":
+        # Data of catalyst spectra and reference spectra
+        dataCat = pd.read_csv(r''+name_dataCat, sep="\t", header = None)
+        dataCat = dataCat.values
+        dataCat = np.delete(dataCat, 0, axis=1)
+        dataCat = dataCat.T
+        
+        dataRef = pd.read_csv(r''+name_dataRef, sep="\t", header = None)
+        dataRef = dataRef.values
+        dataRef = np.delete(dataRef, 0, axis=1)
+        dataRef = dataRef.T
+        
     # Data of catalyst spectra and reference spectra
     dataCat = pd.read_csv(r''+name_dataCat, sep="\t") # , header = None) # if dataset got header: comment last argument out (can't compute strings!))
     dataCat = dataCat.values

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -28,8 +28,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 # The following two lines import stylesheets to format graphs. If you don't have any, comment them out
-if os.environ['LOGNAME'] == 'jakub' :
-    plt.style.use('/home/jakub/HESSENBOX-DA/Diverses/TU_Design.mplstyle')
+#if os.environ['LOGNAME'] == 'jakub' :
+#    plt.style.use('/home/jakub/HESSENBOX-DA/Diverses/TU_Design.mplstyle')
 
 '''
 _______________________________________________________________________________
@@ -521,7 +521,7 @@ DD_yUnit = OptionMenu(PSD_GUI, yUnit, *yUnit_list)
 DD_yUnit.config(width=14)
 DD_yUnit.pack()
 
-Label_DD_yUnit = Label(PSD_GUI, text = 'Choose your x label!').pack()
+Label_DD_xUnit = Label(PSD_GUI, text = 'Choose your x label!').pack()
 
 xUnit_list = {'Wavenumber in 1/cm': r'$\tilde{\nu}$ / cm$^{-1}$', 'Energy in eV': r'$E$ / eV', 'Wavelength in nm': r'$\lambda$ / nm', 'Raman Shift in 1/cm': r'$\Delta\tilde{\nu}$ / cm$^{-1}$'}
 xUnit = StringVar(PSD_GUI)

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -656,7 +656,10 @@ Label_DD_yUnit = Label(PSD_GUI, text = 'Choose your y label!').pack()
 
 yUnit_list = {'-lg(R)': r'-lg($R$)', 'Extinction': r'$E$', 'Transmission in %': r'$T$ / %', 'Absorption in %': r'$A$ / %', 'Intensity in a.U.': r'$I$ / a.U.'}
 yUnit = StringVar(PSD_GUI)
-yUnit.set('-lg(R)')
+if instrument.get() == "Bruker/OPUS (DRIFTS)":
+    yUnit.set('-lg(R)')
+elif instrument.get() == "Horiba/LabSpec (Raman)":
+    yUnit.set('Intensity in a.U.')
 DD_yUnit = OptionMenu(PSD_GUI, yUnit, *yUnit_list)
 DD_yUnit.config(width=14)
 DD_yUnit.pack()

--- a/psd_gui.py
+++ b/psd_gui.py
@@ -84,7 +84,7 @@ def PSD_calc(): # Calculates PSD spectra
         name_dataRef = FileOpen(text)
         
         # Data of catalyst spectra and reference spectra
-        dataCat = pd.read_csv(r''+name_dataCat, sep="\t")#, header = None) # Maybe comment header = None
+        dataCat = pd.read_csv(r''+name_dataCat, sep="\t", header = None) # Maybe comment header = None
         dataCat = dataCat.values
         t_inp = np.genfromtxt(r''+name_t, delimiter="\t")
         
@@ -107,7 +107,7 @@ def PSD_calc(): # Calculates PSD spectra
         name_dataRef = FileOpen(text)
         
         # Data of catalyst spectra and reference spectra
-        dataCat = pd.read_csv(r''+name_dataCat, sep="\t")#, header = None) # Maybe comment header = None
+        dataCat = pd.read_csv(r''+name_dataCat, sep="\t", header = None) # Maybe comment header = None
         dataCat = dataCat.values
         
         # Calculating t_inp into seconds
@@ -289,7 +289,7 @@ def PointPicking():
     text = 'Path of your spectra'
     name_dataSpectra = FileOpen(text)
 
-    if 'PSD' in name_dataSpectra:
+    if '_PSD_' in name_dataSpectra:
         # Data of PSD spectra
         dataSpectra = pd.read_csv(r''+name_dataSpectra, sep="\t")
         dataSpectra = dataSpectra.values
@@ -538,7 +538,7 @@ def Baseline(): # generate and substract baseline and PSD
     data_baseline = np.concatenate((Energy_values, I_bl),axis = 1) # Concatenate Energy_values and baseline back into 'data'       
     
     # Save the baseline
-                     
+                  
     if instrument.get() == "Horiba/LabSpec (Raman)":
         data_baseline = data_baseline.T
         data_baseline = np.concatenate((t_save,data_baseline),axis = 1) # Concatenate t_save and baseline_data 


### PR DESCRIPTION
Hi Jakob,

ich habe mich entschlossen, das dropdown-Menü für Raman/DRIFTS rauszunehmen, weil war 1.) nur Spielerei und 2.) will ich für Raman noch Funktionen einbauen, die für DRIFTS irrelevant sind.
Die Branch 'BaselineCorrectionOnlyDRIFTS' basiert auf der 'RectangularFunction' und hat die Basislinien-Korrektur implementiert. Kannst ja mal reinschauen, ob das gepullt werden soll.
Die neue Funktion 'baseline' erstellt lediglich die Basislinie, womit über 'PSD' oder 'difference spectra' weitergearbeitet werden kann.  Außerdem habe ich bei 'peak' bzw. jetzt 'point picking' eingebaut, dass bei TRS nur 10 Spektren angezeigt werden und die picked points am Ende als 'spectra_BLpoints.txt' statt 'spectra_peaks.txt' gespeichert werden.